### PR TITLE
omit image push credentials for Backstage CI

### DIFF
--- a/.tekton/templates/pipeline.yaml
+++ b/.tekton/templates/pipeline.yaml
@@ -20,7 +20,6 @@ spec:
     type: string
     default: {{ .Values.dockerfilePath }}
   workspaces:
-  - name: quay-credentials
   - name: shared-data
   tasks:
     - name: fetch-source
@@ -41,8 +40,6 @@ spec:
         name: buildah
         kind: ClusterTask
       workspaces:
-      - name: dockerconfig
-        workspace: quay-credentials
       - name: source
         workspace: shared-data
       params:

--- a/.tekton/templates/pipelinerun.yaml
+++ b/.tekton/templates/pipelinerun.yaml
@@ -7,9 +7,6 @@ spec:
   pipelineRef:
     name: devhub-build
   workspaces:
-  - name: quay-credentials
-    secret:
-      secretName: quay-credentials
   - name: shared-data
     volumeClaimTemplate:
       spec:


### PR DESCRIPTION
When I remove the workspace references, I get a clean push to the internal OpenShift registry without any special credential configuration. 

I think this might be nice since we don't have to deal with credentials or external registry config. If we default the Backstage Helm chart to pull from the internal registry, then we can have pretty hands-off CI/CD for Backstage.
