### PR TITLE
link schedule config to GitHub provider

### DIFF
--- a/packages/backend/src/plugins/catalog.ts
+++ b/packages/backend/src/plugins/catalog.ts
@@ -66,11 +66,7 @@ export default async function createPlugin(
     builder.addEntityProvider(
       GithubEntityProvider.fromConfig(env.config, {
         logger: env.logger,
-        schedule: env.scheduler.createScheduledTaskRunner({
-          frequency: { minutes: 30 },
-          timeout: { minutes: 3 },
-          initialDelay: { minutes: 1 },
-        }),
+        scheduler: env.scheduler,
       }),
     );
   }


### PR DESCRIPTION
Use app config to control GitHub entity provider schedule